### PR TITLE
Teams prod env revised to successfully sync apps

### DIFF
--- a/envs/dev/templates/team-carmen.yaml
+++ b/envs/dev/templates/team-carmen.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://github.com/CarmenAPuccio/GeoLocationAPI
     path: templates
-    targetRevision: master
+    targetRevision: HEAD
   syncPolicy:
     automated:
       prune: true

--- a/envs/dev/values.yaml
+++ b/envs/dev/values.yaml
@@ -2,7 +2,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://github.com/aws-samples/ssp-eks-workloads
+    repoURL: https://github.com/youngjeong46/ssp-eks-workloads
     targetRevision: main
   ingress:
     host: dev.example.com

--- a/envs/dev/values.yaml
+++ b/envs/dev/values.yaml
@@ -2,7 +2,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://github.com/youngjeong46/ssp-eks-workloads
+    repoURL: https://github.com/aws-samples/ssp-eks-workloads
     targetRevision: main
   ingress:
     host: dev.example.com

--- a/envs/prod/templates/team-carmen.yaml
+++ b/envs/prod/templates/team-carmen.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://github.com/CarmenAPuccio/GeoLocationAPI
     path: templates
-    targetRevision: master
+    targetRevision: HEAD
   syncPolicy:
     automated:
       prune: true

--- a/envs/prod/templates/team-carmen.yaml
+++ b/envs/prod/templates/team-carmen.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: https://github.com/CarmenAPuccio/GeoLocationAPI
     path: templates
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: master
   syncPolicy:
     automated:
       prune: true

--- a/envs/prod/templates/team-riker.yaml
+++ b/envs/prod/templates/team-riker.yaml
@@ -12,8 +12,12 @@ spec:
     server: {{ .Values.spec.destination.server }}
   source:
     repoURL: {{ .Values.spec.source.repoURL }}
-    path: teams/team-riker/prod
     targetRevision: {{ .Values.spec.source.targetRevision }}
+    path: teams/team-riker/prod
+    helm:
+      parameters:
+      - name: spec.ingress.host
+        value: {{ .Values.spec.ingress.host }}
   syncPolicy:
     automated:
       prune: true

--- a/envs/prod/values.yaml
+++ b/envs/prod/values.yaml
@@ -5,4 +5,4 @@ spec:
     repoURL: https://github.com/aws-samples/ssp-eks-workloads
     targetRevision: main
   ingress:
-    host:
+    host: prod.example.com

--- a/envs/prod/values.yaml
+++ b/envs/prod/values.yaml
@@ -2,7 +2,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://github.com/youngjeong46/ssp-eks-workloads
+    repoURL: https://github.com/aws-samples/ssp-eks-workloads
     targetRevision: main
   ingress:
     host: prod.example.com

--- a/envs/prod/values.yaml
+++ b/envs/prod/values.yaml
@@ -2,7 +2,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://github.com/aws-samples/ssp-eks-workloads
+    repoURL: https://github.com/youngjeong46/ssp-eks-workloads
     targetRevision: main
   ingress:
     host: prod.example.com

--- a/envs/test/templates/team-carmen.yaml
+++ b/envs/test/templates/team-carmen.yaml
@@ -14,7 +14,7 @@ spec:
     repoURL: https://github.com/CarmenAPuccio/GeoLocationAPI
     branch: master
     path: templates
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: HEAD
   syncPolicy:
     automated:
       prune: true

--- a/envs/test/templates/team-riker.yaml
+++ b/envs/test/templates/team-riker.yaml
@@ -12,8 +12,12 @@ spec:
     server: {{ .Values.spec.destination.server }}
   source:
     repoURL: {{ .Values.spec.source.repoURL }}
-    path: teams/team-riker/test
     targetRevision: {{ .Values.spec.source.targetRevision }}
+    path: teams/team-riker/test
+    helm:
+      parameters:
+      - name: spec.ingress.host
+        value: {{ .Values.spec.ingress.host }}
   syncPolicy:
     automated:
       prune: true

--- a/envs/test/values.yaml
+++ b/envs/test/values.yaml
@@ -5,4 +5,4 @@ spec:
     repoURL: https://github.com/aws-samples/ssp-eks-workloads
     targetRevision: main
   ingress:
-    host:
+    host: test.example.com

--- a/envs/test/values.yaml
+++ b/envs/test/values.yaml
@@ -2,7 +2,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://github.com/aws-samples/ssp-eks-workloads
+    repoURL: https://github.com/youngjeong46/ssp-eks-workloads
     targetRevision: main
   ingress:
     host: test.example.com

--- a/envs/test/values.yaml
+++ b/envs/test/values.yaml
@@ -2,7 +2,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://github.com/youngjeong46/ssp-eks-workloads
+    repoURL: https://github.com/aws-samples/ssp-eks-workloads
     targetRevision: main
   ingress:
     host: test.example.com


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PR addresses couple of issues:
- Team Riker does not sync successfully due to misconfigured host address on the `ingress` resource. This is addressed with adding the right parameter.
- Team Carmen did not sync properly due to pointing to the wrong branch (`main` instead of `master`). This changes that to `HEAD` to sync successfully.

e2e-test was completed successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
