### PR TITLE
Guard duty findings generation

### DIFF
--- a/security/envs/dev/Chart.yaml
+++ b/security/envs/dev/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.0"
-name: dev-security-ebs-encryption
-description: App of apps chart for the dev EKS environment using security best practices.
+name: dev-security
+description: App of apps chart for the dev EKS environment using security best practices
 version: 0.1.0

--- a/security/envs/dev/templates/team-danger.yaml
+++ b/security/envs/dev/templates/team-danger.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: team-danger
+  namespace: argocd
+  labels:
+    {{- toYaml .Values.labels | nindent 4 }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: danger
+    server: {{ .Values.spec.destination.server }}
+  project: default
+  source:
+    path: teams/team-danger/dev
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: {{ .Values.spec.source.targetRevision }}
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true

--- a/teams/team-danger/dev/Chart.yaml
+++ b/teams/team-danger/dev/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+name: team-danger-dev
+description: Team Danger applications for the Dev environment.
+version: 0.1.0

--- a/teams/team-danger/dev/templates/privileged-pod.yaml
+++ b/teams/team-danger/dev/templates/privileged-pod.yaml
@@ -1,11 +1,13 @@
+# This is a privileged pod that can be used to test Guard Duty findings generation
 apiVersion: v1
 kind: Pod
 metadata:
   name: privileged-pod
 spec:
   containers:
-  - name: centos
-    image: centos
-    command: ['sh', '-c', 'sleep 999']
-    securityContext:
-       privileged: true
+    - name: app
+      image: centos
+      command: ["/bin/sh"]
+      args: ["-c", "sleep 999"]
+      securityContext:
+        privileged: true

--- a/teams/team-danger/dev/templates/privileged-pod.yaml
+++ b/teams/team-danger/dev/templates/privileged-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged-pod
+spec:
+  containers:
+  - name: centos
+    image: centos
+    command: ['sh', '-c', 'sleep 999']
+    securityContext:
+       privileged: true

--- a/teams/team-danger/dev/values.yaml
+++ b/teams/team-danger/dev/values.yaml
@@ -1,0 +1,9 @@
+labels:
+  env: dev
+  team: danger
+spec:
+  env:
+  ingress:
+    host:
+    region:
+    type: alb


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a sample workload with team-danger running a pod in a privileged mode. This pod generates the `PrivilegeEscalation:Kubernetes/PrivilegedContainer` GuardDuty finding as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
