### PR TITLE
updating workload for team-danger to test runtime feature in guardduty

### DIFF
--- a/teams/team-danger/dev/templates/privileged-pod.yaml
+++ b/teams/team-danger/dev/templates/privileged-pod.yaml
@@ -1,13 +1,16 @@
-# This is a privileged pod that can be used to test Guard Duty findings generation
+# This is a privileged pod that can be used to test runtime findings in Amazon GuardDuty
 apiVersion: v1
 kind: Pod
 metadata:
-  name: privileged-pod
+  name: ubuntunetcat
+  labels:
+    app: ubuntunetcat
 spec:
   containers:
-    - name: app
-      image: centos
-      command: ["/bin/sh"]
-      args: ["-c", "sleep 999"]
-      securityContext:
-        privileged: true
+  - image: redora/ubuntunetcat
+    command:
+      - "sleep"
+      - "60000"
+    imagePullPolicy: IfNotPresent
+    name: ubuntunetcat
+  restartPolicy: Always


### PR DESCRIPTION
Updating workload for `team-danger` to test runtime monitoring feature for GuardDuty
